### PR TITLE
Rename 'dimlId' to 'configUrl' and remove some 'dimlId' attributes.

### DIFF
--- a/config/content_class.hierarchy
+++ b/config/content_class.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/content_class.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/content_class.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/cs/contentclass" />

--- a/config/content_class.hierarchy
+++ b/config/content_class.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/content_class.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/content_class.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/cs/contentclass" />

--- a/config/dcat_access_rights.list
+++ b/config/dcat_access_rights.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_access_rights.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_access_rights.list">
     <listItems>
         <listItem id="nonPublic">
             <names>

--- a/config/dcat_access_rights.list
+++ b/config/dcat_access_rights.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_access_rights.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_access_rights.list">
     <listItems>
         <listItem id="nonPublic">
             <names>

--- a/config/dcat_availability.list
+++ b/config/dcat_availability.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_availability.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_availability.list">
     <listItems>
         <listItem id="experimental">
             <names>

--- a/config/dcat_availability.list
+++ b/config/dcat_availability.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_availability.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_availability.list">
     <listItems>
         <listItem id="experimental">
             <names>

--- a/config/dcat_data_theme.list
+++ b/config/dcat_data_theme.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_data_theme.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_data_theme.list">
     <listItems>
         <listItem id="econ">
             <names>

--- a/config/dcat_data_theme.list
+++ b/config/dcat_data_theme.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_data_theme.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_data_theme.list">
     <listItems>
         <listItem id="econ">
             <names>

--- a/config/dcat_status.list
+++ b/config/dcat_status.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_status.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_status.list">
     <listItems>
         <listItem id="deprecated">
             <names>

--- a/config/dcat_status.list
+++ b/config/dcat_status.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_status.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_status.list">
     <listItems>
         <listItem id="deprecated">
             <names>

--- a/config/dcat_update_frequency.list
+++ b/config/dcat_update_frequency.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_update_frequency.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_update_frequency.list">
     <listItems>
         <listItem id="other">
             <names>

--- a/config/dcat_update_frequency.list
+++ b/config/dcat_update_frequency.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_update_frequency.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/dcat_update_frequency.list">
     <listItems>
         <listItem id="other">
             <names>

--- a/config/information_area.hierarchy
+++ b/config/information_area.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_area.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_area.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infomr" />

--- a/config/information_area.hierarchy
+++ b/config/information_area.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_area.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_area.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infomr" />

--- a/config/information_domain.hierarchy
+++ b/config/information_domain.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_domain.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_domain.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infdom/" />

--- a/config/information_domain.hierarchy
+++ b/config/information_domain.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_domain.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_domain.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infdom/" />

--- a/config/information_object.hierarchy
+++ b/config/information_object.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_object.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_object.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infobj" />

--- a/config/information_object.hierarchy
+++ b/config/information_object.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_object.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_object.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infobj" />

--- a/config/information_objects.graph
+++ b/config/information_objects.graph
@@ -1,4 +1,4 @@
-<graph xmlns="https://github.com/Region-Skane-SDI/diml/graph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/graph https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/graph.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_objects.graph">
+<graph xmlns="https://github.com/Region-Skane-SDI/diml/graph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/graph https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/graph.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_objects.graph">
     <nodes>
         <node id="Personobjekt">
             <names>

--- a/config/information_objects.graph
+++ b/config/information_objects.graph
@@ -1,4 +1,4 @@
-<graph xmlns="https://github.com/Region-Skane-SDI/diml/graph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/graph https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/graph.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_objects.graph">
+<graph xmlns="https://github.com/Region-Skane-SDI/diml/graph" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/graph https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/graph.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_objects.graph">
     <nodes>
         <node id="Personobjekt">
             <names>

--- a/config/information_owner.hierarchy
+++ b/config/information_owner.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_owner.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_owner.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infag/" />

--- a/config/information_owner.hierarchy
+++ b/config/information_owner.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_owner.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/information_owner.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/infstyr/id/infag/" />

--- a/config/product_owner.hierarchy
+++ b/config/product_owner.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/product_owner.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/product_owner.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/prodOwner/" />

--- a/config/product_owner.hierarchy
+++ b/config/product_owner.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/product_owner.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/product_owner.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/prodOwner/" />

--- a/config/sample_list.list
+++ b/config/sample_list.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/sample_list.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/sample_list.list">
     <listItems>
         <listItem id="1">
             <names>

--- a/config/sample_list.list
+++ b/config/sample_list.list
@@ -1,4 +1,4 @@
-<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/sample_list.list">
+<list xmlns="https://github.com/Region-Skane-SDI/diml/list" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/list https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/list.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/sample_list.list">
     <listItems>
         <listItem id="1">
             <names>

--- a/config/search_structure.hierarchy
+++ b/config/search_structure.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/search_structure.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/search_structure.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/ss/" />

--- a/config/search_structure.hierarchy
+++ b/config/search_structure.hierarchy
@@ -1,4 +1,4 @@
-<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/search_structure.hierarchy">
+<hierarchy xmlns="https://github.com/Region-Skane-SDI/diml/hierarchy" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/hierarchy https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/hierarchy.xsd" configurationUrl="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/search_structure.hierarchy">
     <traits>
         <trait class="extension" subclass="bki-namespace">
             <traitParameter key="value" value="http://bki.skane.se/sdi/id/ss/" />

--- a/sample_config.dimlconfig
+++ b/sample_config.dimlconfig
@@ -5,24 +5,24 @@
         </trait>
     </traits>
     <graphs>
-        <graph configurationUrl="information_objects.graph" />
+        <graph configUrl="information_objects.graph" />
     </graphs>
     <lists>
-        <list configurationUrl="dcat_access_rights.list" />
-        <list configurationUrl="dcat_availability.list" />
-        <list configurationUrl="dcat_data_theme.list" />
-        <list configurationUrl="dcat_status.list" />
-        <list configurationUrl="dcat_update_frequency.list" />
+        <list configUrl="dcat_access_rights.list" />
+        <list configUrl="dcat_availability.list" />
+        <list configUrl="dcat_data_theme.list" />
+        <list configUrl="dcat_status.list" />
+        <list configUrl="dcat_update_frequency.list" />
     </lists>
     <hierarchies>
-        <hierarchy configurationUrl="search_structure.hierarchy" />
-        <hierarchy configurationUrl="information_owner.hierarchy" />
-        <hierarchy configurationUrl="product_owner.hierarchy" />
-        <hierarchy configurationUrl="information_domain.hierarchy" />
-        <hierarchy configurationUrl="information_area.hierarchy" />
-        <hierarchy configurationUrl="information_object.hierarchy" />
+        <hierarchy configUrl="search_structure.hierarchy" />
+        <hierarchy configUrl="information_owner.hierarchy" />
+        <hierarchy configUrl="product_owner.hierarchy" />
+        <hierarchy configUrl="information_domain.hierarchy" />
+        <hierarchy configUrl="information_area.hierarchy" />
+        <hierarchy configUrl="information_object.hierarchy" />
         <!-- Exempel ska uppdateras efter hand som de förekommer i en dataprodukt -->
-        <hierarchy configurationUrl="content_class.hierarchy" />
+        <hierarchy configUrl="content_class.hierarchy" />
     </hierarchies>
     <dataSystemColumns>
         <dataSystemColumn id="DIML_{{TableName}}_ID" type="recordid">

--- a/sample_config.dimlconfig
+++ b/sample_config.dimlconfig
@@ -1,28 +1,28 @@
-<config xmlns="https://github.com/Region-Skane-SDI/diml/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/config https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/dimlconfig.xsd" defaultLanguage="sv" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/sample_config.dimlconfig">
+<config xmlns="https://github.com/Region-Skane-SDI/diml/config" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/config https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/dimlconfig.xsd" defaultLanguage="sv">
     <traits>
         <trait class="defaultConfigNamespace">
             <traitParameter key="value" value="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/config/" />
         </trait>
     </traits>
     <graphs>
-        <graph dimlId="information_objects.graph" />
+        <graph configurationUrl="information_objects.graph" />
     </graphs>
     <lists>
-        <list dimlId="dcat_access_rights.list" />
-        <list dimlId="dcat_availability.list" />
-        <list dimlId="dcat_data_theme.list" />
-        <list dimlId="dcat_status.list" />
-        <list dimlId="dcat_update_frequency.list" />
+        <list configurationUrl="dcat_access_rights.list" />
+        <list configurationUrl="dcat_availability.list" />
+        <list configurationUrl="dcat_data_theme.list" />
+        <list configurationUrl="dcat_status.list" />
+        <list configurationUrl="dcat_update_frequency.list" />
     </lists>
     <hierarchies>
-        <hierarchy dimlId="search_structure.hierarchy" />
-        <hierarchy dimlId="information_owner.hierarchy" />
-        <hierarchy dimlId="product_owner.hierarchy" />
-        <hierarchy dimlId="information_domain.hierarchy" />
-        <hierarchy dimlId="information_area.hierarchy" />
-        <hierarchy dimlId="information_object.hierarchy" />
+        <hierarchy configurationUrl="search_structure.hierarchy" />
+        <hierarchy configurationUrl="information_owner.hierarchy" />
+        <hierarchy configurationUrl="product_owner.hierarchy" />
+        <hierarchy configurationUrl="information_domain.hierarchy" />
+        <hierarchy configurationUrl="information_area.hierarchy" />
+        <hierarchy configurationUrl="information_object.hierarchy" />
         <!-- Exempel ska uppdateras efter hand som de förekommer i en dataprodukt -->
-        <hierarchy dimlId="content_class.hierarchy" />
+        <hierarchy configurationUrl="content_class.hierarchy" />
     </hierarchies>
     <dataSystemColumns>
         <dataSystemColumn id="DIML_{{TableName}}_ID" type="recordid">

--- a/sample_dataproduct3.dataproduct
+++ b/sample_dataproduct3.dataproduct
@@ -1,0 +1,327 @@
+<dataProduct xmlns="https://github.com/Region-Skane-SDI/diml/dataproduct" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="https://github.com/Region-Skane-SDI/diml/dataproduct https://raw.githubusercontent.com/Region-Skane-SDI/diml-schemas/main/v0/dataproduct.xsd" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/sample_dataproduct.dataproduct" uniqueName="" targetPlatform="msfabric-lakehouse">
+    <names>
+        <name language="sv">Anställningar</name>
+    </names>
+    <descriptions>
+        <description type="plain" language="sv">Kort sammanfattande beskrivning av dataprodukten</description>
+        <description type="md" language="sv">
+			## dcat
+			TODO: Add decsription
+
+			| Namn | Typ | Krävs | Defaultvärde | Ärvs från | Beskrivning |
+			| ---- | --- | ----- | ------------ | --------- | ----------- |
+			| dcatAccessRights | [dcatAccessRightsType](#dcatAccessRightsType) | Ja |  |  | Anger vilka åtkomsträttigheter som finns för dataprodukten i datakatalogen. Följer standarden DCAT-AP, mer information finns här: https://docs.dataportal.se/dcat/en/#5.5 |
+			| dcatAvailability | [dcatAvailabilityType](#dcatAvailabilityType) | Ja |  |  | Anger dataproduktens tillgänglighet i datakatalogen. Följer standarden DCAT-AP, mer information finns här: https://docs.dataportal.se/dcat/en/#5.9 |
+			| dcatDataTheme | [dcatDataThemeType](#dcatDataThemeType) | Ja |  |  | Anger vilket datatema dataprodukten tillhör i datakatalogen. Följer standarden DCAT-AP, mer information finns här: https://docs.dataportal.se/dcat/en/#5.2 |
+			| dcatStatus | [dcatStatusType](#dcatStatusType) | Ja |  |  | Anger dataproduktens status i datakatalogen. Följer standarden DCAT-AP, mer information finns här: https://docs.dataportal.se/dcat/en/#5.8 |
+			| dcatUpdateFrequency | [dcatUpdateFrequencyType](#dcatUpdateFrequencyType) | Ja |  |  | Anger dataproduktens uppdateringsfrekvens i datakatalogen. Följer standarden DCAT-AP, mer information finns här: https://docs.dataportal.se/dcat/en/#5.4 |
+		</description>
+    </descriptions>
+    <dcat dcatDataTheme="econ" dcatAccessRights="public" dcatUpdateFrequency="daily" dcatAvailability="available" dcatStatus="completed" />
+    <traits>
+        <trait class="category" subclass="informationOwner.hierarchy">
+            <traitParameter key="value">
+                <value>dirhr</value>
+                <value>direkonomi</value>
+            </traitParameter>
+        </trait>
+        <trait class="category" subclass="searchStructure.hierarchy">
+            <traitParameter key="value" value="hr2" />
+        </trait>
+        <!-- The remaining category traits should be updated in similar manner to the above -->
+        <trait class="category" subclass="productOwner">
+            <traitParameter key="value" value="SDI Plattform" />
+        </trait>
+        <trait class="category" subclass="contentClass">
+            <traitParameter key="value" value="Raw" />
+        </trait>
+        <trait class="icon">
+            <traitParameter key="value" value="bi-wallet" />
+        </trait>
+        <trait class="infoClass">
+            <traitParameter key="value" value="K1R1T1" />
+        </trait>
+        <trait class="targetUptimePercent">
+            <traitParameter key="value" value="99.9" />
+        </trait>
+        <trait class="tableNamePrefix">
+            <traitParameter key="value" value="sampleprefix" />
+        </trait>
+        <trait class="tableNameSuffix">
+            <traitParameter key="value" value="samplesuffix" />
+        </trait>
+        <trait class="tableSchema">
+            <traitParameter key="value" value="dbo" />
+        </trait>
+        <trait class="pii" />
+    </traits>
+    <dataInputs>
+        <dataInput id="src1" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml/main/samples/sample_datasource_sql.datasource" channelId="sql" />
+        <dataInput id="src2" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml/main/samples/sample_datasource_sql.datasource" channelId="parquetfile" />
+    </dataInputs>
+    <tables>
+        <table id="Person">
+            <names>
+                <name language="sv">Person</name>
+            </names>
+            <descriptions>
+                <description type="plain" language="sv">Beskrivning i vanlig text...</description>
+                <description type="md" language="sv">##Beskrivning i markdown...
+Test</description>
+                <description type="logicMd" language="sv">Beskrivning av logik i markdown...</description>
+            </descriptions>
+            <businessKey>
+                <value>Personnr</value>
+            </businessKey>
+            <tableInstances existsFromStageId="" existsToStageId="">
+                <tableInstance stageId="PreStorage" alias="PersonPreStorage" />
+            </tableInstances>
+            <columns>
+                <column id="Personnr">
+                    <names>
+                        <name language="sv">Personnr</name>
+                    </names>
+                    <dimlDataType id="ssn" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <columnInstances>
+                        <columnInstance stageId="PreStorage" alias="PersonnrPreStorage">
+                            <dimlDataType id="ssn" isNullable="true" />
+                        </columnInstance>
+                    </columnInstances>
+                    <traits>
+                        <trait class="pii" />
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Person/Personnr</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+                <column id="Namn">
+                    <names>
+                        <name language="sv">Namn</name>
+                    </names>
+                    <dimlDataType id="fullName" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="pii" />
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Person/Namn</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+                <column id="Alder">
+                    <names>
+                        <name language="sv">Alder</name>
+                    </names>
+                    <dimlDataType id="age" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Person/Alder</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+            </columns>
+            <sampleData>
+                <sampleDataRow>
+                    <value>1234567890</value>
+                    <value>Asdfgh</value>
+                    <value>23</value>
+                </sampleDataRow>
+            </sampleData>
+        </table>
+        <table id="Anstallning">
+            <names>
+                <name language="sv">Anstallning</name>
+            </names>
+            <descriptions>
+                <description type="plain" language="sv">Beskrivning...</description>
+                <description type="md" language="sv">Beskrivning...</description>
+            </descriptions>
+            <businessKey>
+                <value>Personnr</value>
+                <value>Anstallningsnr</value>
+            </businessKey>
+            <commonColumns>
+                <commonColumn id="verksamhetsomrade" />
+            </commonColumns>
+            <columns>
+                <column id="Personnr">
+                    <names>
+                        <name language="sv">Personnr</name>
+                    </names>
+                    <dimlDataType id="ssn" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="pii" />
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Anstallning/Personnr</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+                <column id="Anstallningsnr">
+                    <names>
+                        <name language="sv">Anstallningsnr</name>
+                    </names>
+                    <dimlDataType id="integer" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Anstallning/Anstallningsnr</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+                <column id="Startdatum">
+                    <names>
+                        <name language="sv">Startdatum</name>
+                    </names>
+                    <dimlDataType id="date" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Anstallning/Startdatum</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+                <column id="Slutdatum">
+                    <names>
+                        <name language="sv">Slutdatum</name>
+                    </names>
+                    <dimlDataType id="date" isNullable="false" />
+                    <descriptions>
+                        <description type="plain" language="sv">Beskrivning...</description>
+                        <description type="md" language="sv">Beskrivning...</description>
+                    </descriptions>
+                    <traits>
+                        <trait class="isGreaterThan">
+                            <traitParameter key="column" value="Startdatum" />
+                        </trait>
+                        <trait class="columnSources">
+                            <traitParameter key="value">
+                                <value>src1/Anstallning/Slutdatum</value>
+                            </traitParameter>
+                        </trait>
+                    </traits>
+                </column>
+            </columns>
+            <tableRelations>
+                <tableRelation id="tableRelation1" targetTable="Person">
+                    <relationColumns columnName="Personnr" targetColumnName="Personnr" />
+                </tableRelation>
+            </tableRelations>
+            <sampleData>
+                <sampleDataRow>
+                    <value>1234567890</value>
+                    <value>1</value>
+                    <value>2020-01-01</value>
+                    <value>2020-12-31</value>
+                </sampleDataRow>
+            </sampleData>
+        </table>
+    </tables>
+    <customFormats>
+        <customFormat customFormatId="jsondata" formatType="json" schemaLocation="https://..." />
+        <customFormat customFormatId="xmldata" formatType="xml" schemaLocation="https://..." />
+        <customFormat customFormatId="binarydata" formatType="binary" mimeType="img/tiff" />
+    </customFormats>
+    <dataOutputs>
+        <fileOutputs>
+            <fileOutput channelId="csvfile1" fileFormat="csv" table="Person" path="csv/person_{{timestamp}}.csv" encoding="utf8" columnSeparator="tab" rowSeparator="crlf" />
+            <fileOutput channelId="csvfile1" fileFormat="csv" table="Anstallning" path="csv/anstallning_{{timestamp}}.csv" encoding="utf8" columnSeparator="tab" rowSeparator="crlf" />
+            <fileOutput channelId="parquetfile1" fileFormat="parquet" table="Person" path="utdata" />
+            <fileOutput channelId="parquetfile2" fileFormat="parquet" table="Anstallning" path="utdata" />
+            <fileOutput channelId="jsonfiles" fileFormat="custom" customFormatId="jsondata" path="json/{{year}}/{{month}}/{{day}}/jsondata_{{timestamp}}.json" />
+            <fileOutput channelId="xmlfiles" fileFormat="custom" customFormatId="xmldata" path="json/{{year}}/{{month}}/{{day}}/xmldata_{{timestamp}}.xml" />
+            <fileOutput channelId="binaryfiles" fileFormat="custom" customFormatId="xmldata" path="json/{{year}}/{{month}}/{{day}}/binarydata_{{timestamp}}.tiff" />
+        </fileOutputs>
+        <sqlOutputs>
+            <sqlOutput channelId="sql1" sqlOutputType="tsql" />
+            <sqlOutput channelId="sql2" sqlOutputType="sparksql" />
+        </sqlOutputs>
+        <apiOutputs>
+            <apiOutput channelId="api1" apiOutputType="odata" />
+        </apiOutputs>
+    </dataOutputs>
+    <dataFlow>
+        <dataStages>
+            <dataStage id="Raw" type="tempStore" order="1" materialization="table">
+                <traits>
+                </traits>
+                <dataStageTables>
+                    <dataStageTable tableId="Person" sourceTableId="Person">
+                        <columnMappings>
+                            <columnMapping columnId="Personnr" sourceColumnId="Personnr" />
+                            <columnMapping columnId="Namn" sourceColumnId="Namn" />
+                            <columnMapping columnId="Alder" sourceColumnId="Alder" />
+                        </columnMappings>
+                    </dataStageTable>
+                    <dataStageTable tableId="Anstallning" sourceTableId="Anstallning" dataStageFileId="parquet_anstallning" />
+                </dataStageTables>
+            </dataStage>
+            <dataStage id="ControlLogic" type="logic" order="2" materialization="view">
+                <dataStageTable tableId="Person" sourceTableId="Person" transformMethod="sql"> <!-- Framtida möjlighet att ändra materialization på tabell? -->
+                    <columnMappings>
+                        <columnMapping columnId="Personnr" sourceColumnId="Personnr" customSqlExpression="LEFT(Personnr, 12)" />
+                        <columnMapping columnId="Namn" sourceColumnId="Namn" />
+                        <columnMapping columnId="Alder" sourceColumnId="Alder" />
+                    </columnMappings>
+                    <sqlLogicBlocks>
+                    </sqlLogicBlocks>
+                </dataStageTable>
+                <dataStageTable tableId="Anstallning" sourceTableId="Anstallning" />
+            </dataStage>
+            <dataStage id="ControlCast" type="typeCast" order="3" materialization="view">
+            </dataStage>
+            <dataStage id="ControlValidate" type="validate" order="4" materialization="table">
+            </dataStage>
+            <dataStage id="ControlHash" type="hash" order="5" materialization="table">
+            </dataStage>
+            <dataStage id="Storage" type="permaStore" order="6" role="output" materialization="table">
+            </dataStage>
+        </dataStages>
+        <dataIngests>
+            <dataIngest id="load_job_1" dataInputId="src1">
+				<mappings>
+					<sqlToTableMapping tableId="Person" sourceTableId="Person" customSqlExpression="SELECT TOP (1000)
+			{{ColumnList}} FROM {{SourceTable}}" >
+						<columnMappings>
+							<columnMapping columnId="Personnr" sourceColumnId="Personnr" />
+							<columnMapping columnId="Namn" sourceColumnId="Namn" />
+							<columnMapping columnId="Alder" sourceColumnId="Alder" />
+						</columnMappings>
+					</sqlToTableMapping>
+					<sqlToTableMapping tableId="Anstallning" sourceTableId="Anstallning"/>
+				</mappings>
+			</dataIngest>
+        </dataIngests>
+    </dataFlow>
+</dataProduct>

--- a/sample_datatypes.datatypes
+++ b/sample_datatypes.datatypes
@@ -1,4 +1,4 @@
-<dataTypes xmlns="https://github.com/Region-Skane-SDI/diml/datatypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" dimlId="https://raw.githubusercontent.com/Region-Skane-SDI/diml-samples/main/sample_datatypes.datatypes">
+<dataTypes xmlns="https://github.com/Region-Skane-SDI/diml/datatypes" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
     <dataTypeAttributes>
         <dataTypeAttribute id="length" type="int" />
         <dataTypeAttribute id="format" type="string" />


### PR DESCRIPTION
This PR renames 'dimlId' to 'configUrl' attrubute for config elements and files and removes dimlId attribute from .dimlconfig and .datatypes files.
Also added a new product sample
